### PR TITLE
Implement `SerdeObject`

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -847,7 +847,9 @@ impl SerdeObject for Fp {
     }
 
     fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
-        let input: [u8; SIZE] = bytes.try_into().expect(&format!("Expected {} bytes", SIZE));
+        let input: [u8; SIZE] = bytes
+            .try_into()
+            .unwrap_or_else(|_| panic!("Expected {} bytes", SIZE));
         Self::from_bytes_le(&input).into()
     }
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -2,6 +2,7 @@
 //! where `p = 0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab`
 
 use blst::*;
+use halo2curves::serde::SerdeObject;
 
 use core::{
     cmp, fmt,
@@ -516,6 +517,10 @@ fn is_valid_u64(le_bytes: &[u64; 6]) -> bool {
 }
 
 const NUM_BITS: u32 = 381;
+// Number of 64-bit limbs.
+const NUM_LIMBS: usize = 6;
+// Size in bytes.
+const SIZE: usize = 48;
 /// The number of bits we should "shave" from a randomly sampled reputation.
 const REPR_SHAVE_BITS: usize = 384 - NUM_BITS as usize;
 
@@ -790,7 +795,7 @@ impl PrimeField for Fp {
     }
 
     const MODULUS: &'static str = "0x1a0111ea397fe69a4b1ba7b6434bacd764774b84f38512bf6730d2a0f6b0f6241eabfffeb153ffffb9feffffffffaaab";
-    const NUM_BITS: u32 = 381;
+    const NUM_BITS: u32 = NUM_BITS;
     const CAPACITY: u32 = Self::NUM_BITS - 1;
     const TWO_INV: Self = TWO_INV;
     const MULTIPLICATIVE_GENERATOR: Self = GENERATOR;
@@ -829,6 +834,67 @@ impl PrimeFieldBits for Fp {
             hex("0x1a0111ea397fe69a"),
         ];
         ff::FieldBits::new(modulus_limbs)
+    }
+}
+
+impl SerdeObject for Fp {
+    // Don't call this method of untrusted input. No checks performed before unsafe block.
+    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+        debug_assert_eq!(bytes.len(), SIZE);
+        let mut out = blst_fp::default();
+        unsafe { blst_fp_from_lendian(&mut out, bytes.as_ptr()) };
+        Self(out)
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+        let input: [u8; SIZE] = bytes.try_into().expect(&format!("Expected {} bytes", SIZE));
+        Self::from_bytes_le(&input).into()
+    }
+
+    fn to_raw_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(NUM_LIMBS * 8);
+        for limb in self.0.l.iter() {
+            res.extend_from_slice(&limb.to_le_bytes());
+        }
+        res
+    }
+
+    // Don't call this method of untrusted input. No checks performed before unsafe block.
+    fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
+        let inner = [(); NUM_LIMBS].map(|_| {
+            let mut buf = [0; 8];
+            reader.read_exact(&mut buf).unwrap();
+            u64::from_le_bytes(buf)
+        });
+
+        let mut out = blst_fp::default();
+        unsafe { blst_fp_from_uint64(&mut out, inner.as_ptr()) };
+        Self(out)
+    }
+
+    fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut inner = [0u64; NUM_LIMBS];
+        for limb in inner.iter_mut() {
+            let mut buf = [0; 8];
+            reader.read_exact(&mut buf)?;
+            *limb = u64::from_le_bytes(buf);
+        }
+        let out = Self::from_u64s_le(&inner);
+        if out.is_none().into() {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid data.",
+            ))
+        } else {
+            Ok(out.unwrap())
+        }
+    }
+
+    fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        for limb in self.0.l.iter() {
+            writer.write_all(&limb.to_le_bytes())?;
+        }
+        Ok(())
     }
 }
 

--- a/src/fp2.rs
+++ b/src/fp2.rs
@@ -1,6 +1,7 @@
 //! This module implements arithmetic over the quadratic extension field Fp2.
 
 use blst::*;
+use halo2curves::serde::SerdeObject;
 
 use core::{
     cmp::{Ord, Ordering, PartialOrd},
@@ -293,6 +294,15 @@ impl Field for Fp2 {
     fn sqrt_ratio(_num: &Self, _div: &Self) -> (Choice, Self) {
         // ff::helpers::sqrt_ratio_generic(num, div)
         unimplemented!()
+    }
+}
+
+// Instead of implmenting [`SerdeObject`] for Fp2, we implement just `write_raw`.
+// This is all we need to implement [`SerdeObject`] for [`G2Affine`].
+impl Fp2 {
+    pub fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        self.c0().write_raw(writer)?;
+        self.c1().write_raw(writer)
     }
 }
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -438,7 +438,6 @@ impl G1Affine {
     pub fn read_raw_checked<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
         let mut buf = [0u8];
         reader.read_exact(&mut buf)?;
-        let _infinity = buf[0] == 1;
 
         let mut buf = [0u8; UNCOMPRESSED_SIZE];
         reader.read_exact(&mut buf)?;

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -481,8 +481,8 @@ impl SerdeObject for G1Affine {
     }
 
     fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        self.x().write_raw(writer)?;
-        self.y().write_raw(writer)
+        self.write_raw_og(writer)?;
+        Ok(())
     }
 }
 

--- a/src/g1.rs
+++ b/src/g1.rs
@@ -418,10 +418,6 @@ impl G1Affine {
     }
 
     pub fn read_raw_og<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
-        let mut buf = [0u8];
-        reader.read_exact(&mut buf)?;
-        let _infinity = buf[0] == 1;
-
         let mut buf = [0u8; UNCOMPRESSED_SIZE];
         reader.read_exact(&mut buf)?;
         let res = Self::from_uncompressed_unchecked(&buf);
@@ -436,9 +432,6 @@ impl G1Affine {
     }
 
     pub fn read_raw_checked<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
-        let mut buf = [0u8];
-        reader.read_exact(&mut buf)?;
-
         let mut buf = [0u8; UNCOMPRESSED_SIZE];
         reader.read_exact(&mut buf)?;
         let res = Self::from_uncompressed(&buf);
@@ -481,8 +474,8 @@ impl SerdeObject for G1Affine {
     }
 
     fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        self.write_raw_og(writer)?;
-        Ok(())
+        self.x().write_raw(writer)?;
+        self.y().write_raw(writer)
     }
 }
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -418,10 +418,6 @@ impl G2Affine {
     }
 
     fn read_raw_og<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
-        let mut buf = [0u8];
-        reader.read_exact(&mut buf)?;
-        let _infinity = buf[0] == 1;
-
         let mut buf = [0u8; UNCOMPRESSED_SIZE];
         reader.read_exact(&mut buf)?;
         let res = Self::from_uncompressed_unchecked(&buf);
@@ -430,16 +426,12 @@ impl G2Affine {
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "not on curve",
+                "Not on curve.",
             ))
         }
     }
 
     fn read_raw_checked<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
-        let mut buf = [0u8];
-        reader.read_exact(&mut buf)?;
-        let _infinity = buf[0] == 1;
-
         let mut buf = [0u8; UNCOMPRESSED_SIZE];
         reader.read_exact(&mut buf)?;
         let res = Self::from_uncompressed(&buf);
@@ -448,7 +440,7 @@ impl G2Affine {
         } else {
             Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
-                "not on curve",
+                "Not on curve.",
             ))
         }
     }
@@ -468,9 +460,7 @@ impl SerdeObject for G2Affine {
     }
 
     fn to_raw_bytes(&self) -> Vec<u8> {
-        let mut res = Vec::with_capacity(UNCOMPRESSED_SIZE);
-        Self::write_raw(self, &mut res).unwrap();
-        res
+        self.to_uncompressed().into()
     }
 
     fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self {
@@ -482,8 +472,7 @@ impl SerdeObject for G2Affine {
     }
 
     fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
-        self.x().write_raw(writer)?;
-        self.y().write_raw(writer)
+        writer.write_all(&self.to_uncompressed())
     }
 }
 

--- a/src/g2.rs
+++ b/src/g2.rs
@@ -7,8 +7,8 @@ use core::{
     iter::Sum,
     ops::{Add, AddAssign, Mul, MulAssign, Neg, Sub, SubAssign},
 };
-use std::convert::TryInto;
 use std::ops::{Deref, DerefMut};
+use std::{convert::TryInto, io::Read};
 
 use blst::*;
 use ff::{Field, PrimeField, WithSmallOrderMulGroup};
@@ -16,6 +16,7 @@ use group::{
     prime::{PrimeCurve, PrimeCurveAffine, PrimeGroup},
     Curve, Group, GroupEncoding, UncompressedEncoding, WnafGroup,
 };
+use halo2curves::serde::SerdeObject;
 use pasta_curves::arithmetic::{Coordinates, CurveAffine, CurveExt};
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -414,6 +415,75 @@ impl G2Affine {
 
     pub const fn compressed_size() -> usize {
         COMPRESSED_SIZE
+    }
+
+    fn read_raw_og<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
+        let mut buf = [0u8];
+        reader.read_exact(&mut buf)?;
+        let _infinity = buf[0] == 1;
+
+        let mut buf = [0u8; UNCOMPRESSED_SIZE];
+        reader.read_exact(&mut buf)?;
+        let res = Self::from_uncompressed_unchecked(&buf);
+        if res.is_some().into() {
+            Ok(res.unwrap())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "not on curve",
+            ))
+        }
+    }
+
+    fn read_raw_checked<R: Read>(mut reader: R) -> Result<Self, std::io::Error> {
+        let mut buf = [0u8];
+        reader.read_exact(&mut buf)?;
+        let _infinity = buf[0] == 1;
+
+        let mut buf = [0u8; UNCOMPRESSED_SIZE];
+        reader.read_exact(&mut buf)?;
+        let res = Self::from_uncompressed(&buf);
+        if res.is_some().into() {
+            Ok(res.unwrap())
+        } else {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "not on curve",
+            ))
+        }
+    }
+}
+
+impl SerdeObject for G2Affine {
+    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+        debug_assert_eq!(bytes.len(), UNCOMPRESSED_SIZE);
+        let input: [u8; UNCOMPRESSED_SIZE] = bytes.try_into().unwrap();
+        Self::from_uncompressed_unchecked(&input).unwrap()
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+        debug_assert_eq!(bytes.len(), UNCOMPRESSED_SIZE);
+        let input: [u8; UNCOMPRESSED_SIZE] = bytes.try_into().unwrap();
+        Self::from_uncompressed(&input).into()
+    }
+
+    fn to_raw_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(UNCOMPRESSED_SIZE);
+        Self::write_raw(self, &mut res).unwrap();
+        res
+    }
+
+    fn read_raw_unchecked<R: Read>(reader: &mut R) -> Self {
+        Self::read_raw_og(reader).unwrap()
+    }
+
+    fn read_raw<R: Read>(reader: &mut R) -> std::io::Result<Self> {
+        Self::read_raw_checked(reader)
+    }
+
+    fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        self.x().write_raw(writer)?;
+        self.y().write_raw(writer)
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -13,6 +13,7 @@ use core::{
 use blst::*;
 use byte_slice_cast::AsByteSlice;
 use ff::{Field, FieldBits, PrimeField, PrimeFieldBits, WithSmallOrderMulGroup};
+use halo2curves::serde::SerdeObject;
 use rand_core::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -350,6 +351,11 @@ impl_add_sub_assign!(Scalar);
 impl_mul!(Scalar);
 impl_mul_assign!(Scalar);
 
+const NUM_BITS: u32 = 255;
+// Number of 64-bit limbs.
+const NUM_LIMBS: usize = 4;
+// Size in bytes.
+const SIZE: usize = 32;
 /// The number of bits we should "shave" from a randomly sampled reputation.
 const REPR_SHAVE_BITS: usize = 256 - Scalar::NUM_BITS as usize;
 
@@ -445,7 +451,7 @@ impl PrimeField for Scalar {
     // Little-endian non-Montgomery form bigint mod p.
     type Repr = [u8; 32];
 
-    const NUM_BITS: u32 = 255;
+    const NUM_BITS: u32 = NUM_BITS;
     const CAPACITY: u32 = Self::NUM_BITS - 1;
     const S: u32 = S;
 
@@ -828,6 +834,71 @@ impl Scalar {
     #[inline]
     pub fn square_assign(&mut self) {
         unsafe { blst_fr_sqr(&mut self.0, &self.0) };
+    }
+}
+
+impl SerdeObject for Scalar {
+    // Don't call this method with untrusted input. No checks performed before unsafe block.
+    fn from_raw_bytes_unchecked(bytes: &[u8]) -> Self {
+        debug_assert_eq!(bytes.len(), SIZE);
+        let bytes: [u8; SIZE] = bytes.try_into().unwrap();
+        let mut out = blst_fr::default();
+        let bytes_u64 = u64s_from_bytes(&bytes);
+        unsafe { blst_fr_from_uint64(&mut out, bytes_u64.as_ptr()) };
+        Self(out)
+    }
+
+    fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
+        let input: [u8; SIZE] = bytes.try_into().expect(&format!("Expected {} bytes", SIZE));
+        Self::from_bytes_le(&input).into()
+    }
+
+    fn to_raw_bytes(&self) -> Vec<u8> {
+        let mut res = Vec::with_capacity(NUM_LIMBS * 8);
+        for limb in self.0.l.iter() {
+            res.extend_from_slice(&limb.to_le_bytes());
+        }
+        res
+    }
+
+    // Don't call this method with untrusted input. No checks performed before unsafe block.
+    fn read_raw_unchecked<R: std::io::Read>(reader: &mut R) -> Self {
+        let mut inner = [0u64; NUM_LIMBS];
+        for limb in inner.iter_mut() {
+            let mut buf = [0; 8];
+            reader.read_exact(&mut buf).unwrap();
+            *limb = u64::from_le_bytes(buf)
+        }
+
+        let mut out = blst_fr::default();
+        unsafe { blst_fr_from_uint64(&mut out, inner.as_ptr()) };
+        Self(out)
+    }
+
+    fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let mut inner = [0u64; NUM_LIMBS];
+        for limb in inner.iter_mut() {
+            let mut buf = [0; 8];
+            reader.read_exact(&mut buf)?;
+            *limb = u64::from_le_bytes(buf);
+        }
+
+        let out = Self::from_u64s_le(&inner);
+        if out.is_none().into() {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Invalid data.",
+            ))
+        } else {
+            Ok(out.unwrap())
+        }
+    }
+
+    fn write_raw<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        for limb in self.0.l.iter() {
+            writer.write_all(&limb.to_le_bytes())?;
+        }
+        Ok(())
     }
 }
 

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -849,7 +849,9 @@ impl SerdeObject for Scalar {
     }
 
     fn from_raw_bytes(bytes: &[u8]) -> Option<Self> {
-        let input: [u8; SIZE] = bytes.try_into().expect(&format!("Expected {} bytes", SIZE));
+        let input: [u8; SIZE] = bytes
+            .try_into()
+            .unwrap_or_else(|_| panic!("Expected {} bytes", SIZE));
         Self::from_bytes_le(&input).into()
     }
 


### PR DESCRIPTION
- Implement `SerdeObject` for `Fp`, `Scalar`, `G1Affine` and `G2Affine`.
- Partially implemented (some auxiliary functions added) in `Fp2` in order to support `G2Affine`.