### PR TITLE
Rename Jubjub structs

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -862,7 +862,7 @@ impl SerdeObject for Fp {
         if bytes.len() != SIZE {
             return None;
         }
-        Some(Self::from_raw_bytes_unchecked(&bytes))
+        Some(Self::from_raw_bytes_unchecked(bytes))
     }
 
     fn to_raw_bytes(&self) -> Vec<u8> {
@@ -878,7 +878,7 @@ impl SerdeObject for Fp {
         let mut bytes = [0u8; SIZE];
         reader
             .read_exact(&mut bytes)
-            .expect(&format!("Expected {} bytes.", SIZE));
+            .unwrap_or_else(|_| panic!("Expected {} bytes.", SIZE));
         Self::from_raw_bytes_unchecked(&bytes)
     }
 
@@ -887,12 +887,12 @@ impl SerdeObject for Fp {
         let mut bytes = [0u8; SIZE];
         reader
             .read_exact(&mut bytes)
-            .expect(&format!("Expected {} bytes.", SIZE));
+            .unwrap_or_else(|_| panic!("Expected {} bytes.", SIZE));
         let out = Self::from_raw_bytes(&bytes);
-        if out.is_none().into() {
-            Err(Error::new(ErrorKind::InvalidData, "Invalid data."))
+        if let Some(out) = out {
+            Ok(out)
         } else {
-            Ok(out.unwrap())
+            Err(Error::new(ErrorKind::InvalidData, "Invalid data."))
         }
     }
 

--- a/src/jubjub/mod.rs
+++ b/src/jubjub/mod.rs
@@ -2,4 +2,4 @@ mod curve;
 mod fr;
 
 pub use curve::*;
-pub use fr::*;
+pub use fr::{Fr, MODULUS};

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -848,7 +848,7 @@ impl SerdeObject for Scalar {
         if bytes.len() != SIZE {
             return None;
         }
-        Some(Self::from_raw_bytes_unchecked(&bytes))
+        Some(Self::from_raw_bytes_unchecked(bytes))
         // let out = Self::from_raw_bytes_unchecked(&bytes);
         // Self::is_less_than_modulus(&out.0.l).then(|| out)
         // Note: The [0, p-1] check is not performed, as it would require a Montgomery reduction.
@@ -866,7 +866,7 @@ impl SerdeObject for Scalar {
         let mut bytes = [0u8; SIZE];
         reader
             .read_exact(&mut bytes)
-            .expect(&format!("Expected {} bytes.", SIZE));
+            .unwrap_or_else(|_| panic!("Expected {} bytes.", SIZE));
         Self::from_raw_bytes_unchecked(&bytes)
     }
 
@@ -874,15 +874,13 @@ impl SerdeObject for Scalar {
         let mut bytes = [0u8; SIZE];
         reader
             .read_exact(&mut bytes)
-            .expect(&format!("Expected {} bytes.", SIZE));
+            .unwrap_or_else(|_| panic!("Expected {} bytes.", SIZE));
         let out = Self::from_raw_bytes(&bytes);
-        if out.is_none().into() {
-            Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Invalid data.",
-            ))
+        use std::io::{Error, ErrorKind};
+        if let Some(out) = out {
+            Ok(out)
         } else {
-            Ok(out.unwrap())
+            Err(Error::new(ErrorKind::InvalidData, "Invalid data."))
         }
     }
 


### PR DESCRIPTION
Jubjub points are exposed directly, and therefore names like `AffinePoint` and `ExtendedPoint` are quite confusing since it looks like they refer to Bls points.

The names have been changed, replacing `Point` sufix and adding `Jubjub` prefix.