### PR TITLE
Allow failure of reading bytes in 'read_raw' for scalar

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -911,8 +911,7 @@ impl SerdeObject for Fp {
         use std::io::{Error, ErrorKind};
         let mut bytes = [0u8; SIZE];
         reader
-            .read_exact(&mut bytes)
-            .unwrap_or_else(|_| panic!("Expected {} bytes.", SIZE));
+            .read_exact(&mut bytes)?;
         let out = Self::from_raw_bytes(&bytes);
         if let Some(out) = out {
             Ok(out)

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -873,8 +873,7 @@ impl SerdeObject for Scalar {
     fn read_raw<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
         let mut bytes = [0u8; SIZE];
         reader
-            .read_exact(&mut bytes)
-            .unwrap_or_else(|_| panic!("Expected {} bytes.", SIZE));
+            .read_exact(&mut bytes)?;
         let out = Self::from_raw_bytes(&bytes);
         use std::io::{Error, ErrorKind};
         if let Some(out) = out {


### PR DESCRIPTION
This makes this function consistent with the points function